### PR TITLE
Make has-selected-item bold

### DIFF
--- a/src/stylesheets/components/_button.scss
+++ b/src/stylesheets/components/_button.scss
@@ -392,6 +392,7 @@ select:disabled {
 
   &.has-selected-item {
     border-color: $black !important;
+    font-weight: $font-weight-bold;
 
     &.active,
     &.focus,


### PR DESCRIPTION
Helps active btn-filter-dropdown stand out a bit more on the page. Discussed with Antoine P.

- [x] Remove hack of toggling `font-weight-bold` from `itou/static/js/htmx_dropdown_filter.js` in `les-emplois`