### PR TITLE
fix: responsive width for .select2-container--bootstrap-5

### DIFF
--- a/src/stylesheets/components/_form.scss
+++ b/src/stylesheets/components/_form.scss
@@ -7,6 +7,10 @@
     font-weight: 700;
     font-size: inherit;
   }
+
+  > .select2-container--bootstrap-5 {
+    width: 100% !important;
+  }
 }
 
 .form-row {


### PR DESCRIPTION
Une fois qu'un widget select2 est téléchargé (`.select2-container--bootstrap-5`) la largeur est fixée selon la taille de l'écran :

```html
<span dir="ltr" data-select2-id="3" style="width: 694.667px;" class="select2 select2-container select2-container--bootstrap-5">
```

Je n'ai pas encore trouvé où dans le code mais je pense c'est fixée en JS pour que les composants sont réponsive à la tialle de l'écran. Le problème arrive quand on change la taille de l'écran, ces composants sont pas réponsive :

<img width="780" alt="Screenshot 2024-09-12 at 15 01 16" src="https://github.com/user-attachments/assets/8067138e-f4e1-4829-91ca-c8acdb8c6fd8">

Dans ce PR je propose une fixe simple où on ajoute une classe qui enforce le composant ne peut pas manger plus de la page que son parent

<img width="593" alt="Screenshot 2024-09-12 at 15 03 08" src="https://github.com/user-attachments/assets/9430bd68-68a2-434b-9cd6-34e2f77b0cba">

Je sais que ce repo est partagé avec des autres services, j'ai donc hésité au proposer juste dans nos styles à nous